### PR TITLE
build: Clarify pin mapping/don't override defines

### DIFF
--- a/grblHAL_Teensy4/src/T40X101_map.h
+++ b/grblHAL_Teensy4/src/T40X101_map.h
@@ -35,9 +35,13 @@
 #error Spindle sync is not supported for T40X101
 #endif
 
-// Default pin assignments allow only one axis to be ganged or auto squared.
-// A axis pin numbers are used for the ganged/auto squared axis.
-// If a second axis is to be ganged/auto squared pin assignments needs to be changed!
+// Default pin assignments set each axis to operate independently
+//  If Y_GANGED / Y_AUTO_SQUARE is set, A pins will be used for the second axis
+//  If X_GANGED / X_AUTO_SQUARE is set, A pins will be used for the second axis
+//  If Z_GANGED / Z_AUTO_SQUARE is set, A pins will be used for the second axis
+//
+// If alternate behavior is desired, edit the pin mapping accordingly
+//
 // Set to 1 to enable, 0 to disable.
 #define X_GANGED        0
 #define X_AUTO_SQUARE   0
@@ -45,7 +49,6 @@
 #define Y_AUTO_SQUARE   0
 #define Z_GANGED        0
 #define Z_AUTO_SQUARE   0
-//
 
 #define X_STEP_PIN      (2u)
 #define X_DIRECTION_PIN (3u)

--- a/grblHAL_Teensy4/src/T41BB5X_Pro_map.h
+++ b/grblHAL_Teensy4/src/T41BB5X_Pro_map.h
@@ -38,17 +38,32 @@
 #define EEPROM_ENABLE   1
 #define EEPROM_IS_FRAM  1
 
-// Default pin assignments allow only one axis to be ganged or auto squared.
-// B axis pin numbers are used for the ganged/auto squared axis.
-// If a second axis is to be ganged/auto squared pin assignments needs to be changed!
-// Set to 1 to enable, 0 to disable.
-#define X_GANGED        1
-#define X_AUTO_SQUARE   1
-#define Y_GANGED        0
-#define Y_AUTO_SQUARE   0
-#define Z_GANGED        0
-#define Z_AUTO_SQUARE   0
+// Default pin assignments set the X axis ganged to the B axis
+//  If Y_GANGED / Y_AUTO_SQUARE is set, B pins will be used for the second axis
+//  If X_GANGED / X_AUTO_SQUARE is set, B pins will be used for the second axis
+//  If Z_GANGED / Z_AUTO_SQUARE is set, B pins will be used for the second axis
 //
+// If alternate behavior is desired, edit the pin mapping accordingly
+//
+// Set to 1 to enable, 0 to disable.
+#ifndef X_GANGED
+#define X_GANGED        1
+#endif
+#ifndef X_AUTO_SQUARE
+#define X_AUTO_SQUARE   1
+#endif
+#ifndef Y_GANGED
+#define Y_GANGED        0
+#endif
+#ifndef Y_AUTO_SQUARE
+#define Y_AUTO_SQUARE   0
+#endif
+#ifndef Z_GANGED
+#define Z_GANGED        0
+#endif
+#ifndef Z_AUTO_SQUARE
+#define Z_AUTO_SQUARE   0
+#endif
 
 #define X_STEP_PIN      (2u)
 #define X_DIRECTION_PIN (3u)

--- a/grblHAL_Teensy4/src/T41U5XBB_map.h
+++ b/grblHAL_Teensy4/src/T41U5XBB_map.h
@@ -32,17 +32,32 @@
 #error Spindle sync is not supported for T41U5XBB
 #endif
 
-// Default pin assignments allow only one axis to be ganged or auto squared.
-// B axis pin numbers are used for the ganged/auto squared axis.
-// If a second axis is to be ganged/auto squared pin assignments needs to be changed!
-// Set to 1 to enable, 0 to disable.
-#define X_GANGED        0
-#define X_AUTO_SQUARE   0
-#define Y_GANGED        0
-#define Y_AUTO_SQUARE   0
-#define Z_GANGED        0
-#define Z_AUTO_SQUARE   0
+// Default pin assignments set each axis to operate independently
+//  If Y_GANGED / Y_AUTO_SQUARE is set, A pins will be used for the second axis
+//  If X_GANGED / X_AUTO_SQUARE is set, B pins will be used for the second axis
+//  If Z_GANGED / Z_AUTO_SQUARE is set, B pins will be used for the second axis
 //
+// If alternate behavior is desired, edit the pin mapping accordingly
+//
+// Set to 1 to enable, 0 to disable.
+#ifndef X_GANGED
+#define X_GANGED        0
+#endif
+#ifndef X_AUTO_SQUARE
+#define X_AUTO_SQUARE   0
+#endif
+#ifndef Y_GANGED
+#define Y_GANGED        0
+#endif
+#ifndef Y_AUTO_SQUARE
+#define Y_AUTO_SQUARE   0
+#endif
+#ifndef Z_GANGED
+#define Z_GANGED        0
+#endif
+#ifndef Z_AUTO_SQUARE
+#define Z_AUTO_SQUARE   0
+#endif
 
 #define X_STEP_PIN      (2u)
 #define X_DIRECTION_PIN (3u)

--- a/grblHAL_Teensy4/src/T41U5XBB_ss_map.h
+++ b/grblHAL_Teensy4/src/T41U5XBB_ss_map.h
@@ -34,17 +34,32 @@
 #error Quadrature encoder and spindle sync cannot be enabled at the same time
 #endif
 
-// Default pin assignments allow only one axis to be ganged or auto squared.
-// B axis pin numbers are used for the ganged/auto squared axis.
-// If a second axis is to be ganged/auto squared pin assignments needs to be changed!
-// Set to 1 to enable, 0 to disable.
-#define X_GANGED        0
-#define X_AUTO_SQUARE   0
-#define Y_GANGED        0
-#define Y_AUTO_SQUARE   0
-#define Z_GANGED        0
-#define Z_AUTO_SQUARE   0
+// Default pin assignments set each axis to operate independently
+//  If Y_GANGED / Y_AUTO_SQUARE is set, A pins will be used for the second axis
+//  If X_GANGED / X_AUTO_SQUARE is set, B pins will be used for the second axis
+//  If Z_GANGED / Z_AUTO_SQUARE is set, B pins will be used for the second axis
 //
+// If alternate behavior is desired, edit the pin mapping accordingly
+//
+// Set to 1 to enable, 0 to disable.
+#ifndef X_GANGED
+#define X_GANGED        0
+#endif
+#ifndef X_AUTO_SQUARE
+#define X_AUTO_SQUARE   0
+#endif
+#ifndef Y_GANGED
+#define Y_GANGED        0
+#endif
+#ifndef Y_AUTO_SQUARE
+#define Y_AUTO_SQUARE   0
+#endif
+#ifndef Z_GANGED
+#define Z_GANGED        0
+#endif
+#ifndef Z_AUTO_SQUARE
+#define Z_AUTO_SQUARE   0
+#endif
 
 #define X_STEP_PIN      (2u)
 #define X_DIRECTION_PIN (3u)


### PR DESCRIPTION
Previously all pin mapping of ganged axes was an exercise left to the
user.

In ac96edd4 this behavior was changed to remove the burden from the user
through the use of sensible default behavior.

This extends that work by:

  - Clarifying the comments explaining the behavior (which were out of
    date in some cases)
  - Expands the explainations to avoid potential mis-configurations
  - Checking if the options if the following options were previously
    defined and only setting them in the event that they were not:
    - `X_GANGED`
    - `X_AUTO_SQUARE`
    - `Y_GANGED`
    - `Y_AUTO_SQUARE`
    - `Z_GANGED`
    - `Z_AUTO_SQUARE`

Users may now define *_GANGED and *_AUTO_SQUARE in `my_machine.h`
without raising compiler warnings or having the values re-defined in the
relevant map file.

All existing pin mappings were left as is to ensure there is no change
in behavior for existing users.