### PR TITLE
Fix enable of safety door by pin declaration instead of enable define

### DIFF
--- a/grblHAL_Teensy4/src/driver.c
+++ b/grblHAL_Teensy4/src/driver.c
@@ -1019,7 +1019,7 @@ inline static control_signals_t systemGetState (void)
 #endif
     signals.feed_hold = (FeedHold.reg->DR & FeedHold.bit) != 0;
     signals.cycle_start = (CycleStart.reg->DR & CycleStart.bit) != 0;
-#ifdef SAFETY_DOOR_PIN
+#ifdef ENABLE_SAFETY_DOOR_INPUT_PIN
     signals.safety_door_ajar = (SafetyDoor.reg->DR & SafetyDoor.bit) != 0;
 #endif
 


### PR DESCRIPTION
Using the SAFETY_DOOR_PIN define for getting the system state leads to error 13 (check door) although ENABLE_SAFETY_DOOR_INPUT_PIN is not defined...