### PR TITLE
Fixed problem with UART definition when using RS485 spindle control.

### DIFF
--- a/grblHAL_Teensy4/src/GRBLHAL2000_map.h
+++ b/grblHAL_Teensy4/src/GRBLHAL2000_map.h
@@ -23,7 +23,10 @@
 #define BOARD_NAME "GRBLHAL2000 - PRINTNC"
 #define HAS_BOARD_INIT
 #define HAS_IOPORTS
+
+#if MODBUS_ENABLE < 1
 #define UART_PORT 8
+#endif
 
 #ifdef NETWORK_HOSTNAME
     #undef NETWORK_HOSTNAME


### PR DESCRIPTION
I made a mistake when enabling the Pi connected UART that broke the RS485 spindle control.

I think that I might need to make more edits so that users can use both the PI UART and RS485 at the same time, but in the meantime I would like to get this fixed to remove confusion.