### PR TITLE
Removed double def of probe pin

### DIFF
--- a/grblHAL_Teensy4/src/T41U5XBB_ss_map.h
+++ b/grblHAL_Teensy4/src/T41U5XBB_ss_map.h
@@ -145,9 +145,6 @@
 #define MOTOR_WARNING_PIN   AUXINPUT1_PIN
 #endif
 
-// Define probe switch input pin.
-#define PROBE_PIN           (15u)
-
 #if QEI_ENABLE
 #define QEI_A_PIN           (30u) // ST1
 #define QEI_B_PIN           (34u) // ST2


### PR DESCRIPTION
This was causing many warnings on compilation. 
This may have been missed in commit 53a82c4, map is now matching the non-spindle sync version.