### PR TITLE
Update platformio.ini

### DIFF
--- a/grblHAL_Teensy4/platformio.ini
+++ b/grblHAL_Teensy4/platformio.ini
@@ -42,7 +42,7 @@ lib_deps = ${common_teensy.lib_deps}
 [env:teensy41]
 board = teensy41
 # platform = ${common_teensy.platform} NOTE: the latest version is broken as of 2022-10-21
-platform = ${common_teensy.platform}@4.16
+platform = ${common_teensy.platform}@4.18.0
 upload_protocol = ${common_teensy.upload_protocol}
 build_flags = ${common_teensy.build_flags}
 lib_deps = ${common_teensy.lib_deps}


### PR DESCRIPTION
for Teensy 4.1
platform = ${common_teensy.platform}@4.16
 doesn't work, now it is 
platform = ${common_teensy.platform}@4.18.0